### PR TITLE
Add missed code for parsing MS Learn info

### DIFF
--- a/Sources/Kysect.Configuin.Core/MsLearnDocumentation/MsLearnDocumentationParser.cs
+++ b/Sources/Kysect.Configuin.Core/MsLearnDocumentation/MsLearnDocumentationParser.cs
@@ -26,7 +26,11 @@ public class MsLearnDocumentationParser : IMsLearnDocumentationParser
 
     public RoslynRules Parse(MsLearnDocumentationRawInfo rawInfo)
     {
-        throw new NotImplementedException();
+        // TODO: implement parsing for other info - SharpFormattingOptionsContent and DotnetFormattingOptionsContent
+
+        return new RoslynRules(
+            rawInfo.QualityRuleInfos.Select(ParseQualityRule).ToList(),
+            rawInfo.StyleRuleInfos.Select(ParseStyleRule).ToList());
     }
 
     public RoslynStyleRule ParseStyleRule(string info)


### PR DESCRIPTION
close #5 

Изначально думал запилить сразу всю логику парсинга максдаун страниц, но потом подумал, что если сейчас реализована логика парсинга для двух основных категорий, то можно отдельно завести ишую на оставшиеся две, чтобы не получить дальнейший прогресс.