### PR TITLE
Add strong typing for RoslynRuleId

### DIFF
--- a/Sources/Directory.Build.props
+++ b/Sources/Directory.Build.props
@@ -1,5 +1,7 @@
 <Project>
     <PropertyGroup>
         <LangVersion>latest</LangVersion>
+        <NoWarn>$(NoWarn);CS1591</NoWarn>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 </Project>

--- a/Sources/Kysect.Configuin.Common/StringExtensions.cs
+++ b/Sources/Kysect.Configuin.Common/StringExtensions.cs
@@ -4,7 +4,7 @@ namespace Kysect.Configuin.Common;
 
 public static class StringExtensions
 {
-    public static string RemovePrefix(this string value, string prefix)
+    public static string WithoutPrefix(this string value, string prefix)
     {
         if (!value.StartsWith(prefix, StringComparison.InvariantCultureIgnoreCase))
             throw new ArgumentException($"String {value} does not start with {prefix}");

--- a/Sources/Kysect.Configuin.Common/StringExtensions.cs
+++ b/Sources/Kysect.Configuin.Common/StringExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Kysect.Configuin.Common;
+
+public static class StringExtensions
+{
+    public static bool StartWithIgnoreCase(this string value, string otherValue)
+    {
+        return value.Substring(0, otherValue.Length).Equals(otherValue, StringComparison.InvariantCultureIgnoreCase);
+    }
+
+    public static string RemovePrefix(this string value, string prefix)
+    {
+        if (!value.StartWithIgnoreCase(prefix))
+            throw new ArgumentException($"String {value} does not start with {prefix}");
+
+        return value.Substring(prefix.Length, value.Length - prefix.Length);
+    }
+}

--- a/Sources/Kysect.Configuin.Common/StringExtensions.cs
+++ b/Sources/Kysect.Configuin.Common/StringExtensions.cs
@@ -4,14 +4,9 @@ namespace Kysect.Configuin.Common;
 
 public static class StringExtensions
 {
-    public static bool StartWithIgnoreCase(this string value, string otherValue)
-    {
-        return value.Substring(0, otherValue.Length).Equals(otherValue, StringComparison.InvariantCultureIgnoreCase);
-    }
-
     public static string RemovePrefix(this string value, string prefix)
     {
-        if (!value.StartWithIgnoreCase(prefix))
+        if (!value.StartsWith(prefix, StringComparison.InvariantCultureIgnoreCase))
             throw new ArgumentException($"String {value} does not start with {prefix}");
 
         return value.Substring(prefix.Length, value.Length - prefix.Length);

--- a/Sources/Kysect.Configuin.Core/EditorConfigParsing/EditorConfigRuleParser.cs
+++ b/Sources/Kysect.Configuin.Core/EditorConfigParsing/EditorConfigRuleParser.cs
@@ -1,5 +1,6 @@
 ﻿using Kysect.Configuin.Core.EditorConfigParsing.Rules;
 using Kysect.Configuin.Core.IniParsing;
+using Kysect.Configuin.Core.RoslynRuleModels;
 
 namespace Kysect.Configuin.Core.EditorConfigParsing;
 
@@ -61,7 +62,7 @@ public class EditorConfigRuleParser : IEditorConfigRuleParser
         if (!Enum.TryParse(line.Value, true, out RoslynRuleSeverity severity))
             throw new ArgumentException($"Cannot parse severity from {line.Value}");
 
-        string ruleId = keyParts[1];
+        var ruleId = RoslynRuleId.Parse(keyParts[1]);
         return new RoslynSeverityEditorConfigRule(ruleId, severity);
     }
 

--- a/Sources/Kysect.Configuin.Core/EditorConfigParsing/Rules/IEditorConfigRule.cs
+++ b/Sources/Kysect.Configuin.Core/EditorConfigParsing/Rules/IEditorConfigRule.cs
@@ -1,4 +1,6 @@
-﻿namespace Kysect.Configuin.Core.EditorConfigParsing.Rules;
+﻿using Kysect.Configuin.Core.RoslynRuleModels;
+
+namespace Kysect.Configuin.Core.EditorConfigParsing.Rules;
 
 public interface IEditorConfigRule
 {
@@ -16,8 +18,9 @@ public record GeneralEditorConfigRule(
 public record RoslynOptionEditorConfigRule(
     string Key,
     string Value,
+    // TODO: ensure that this is supported (severity per option)
     RoslynRuleSeverity? Severity) : IEditorConfigRule;
 
 public record RoslynSeverityEditorConfigRule(
-    string RuleId,
+    RoslynRuleId RuleId,
     RoslynRuleSeverity Severity) : IEditorConfigRule;

--- a/Sources/Kysect.Configuin.Core/Kysect.Configuin.Core.csproj
+++ b/Sources/Kysect.Configuin.Core/Kysect.Configuin.Core.csproj
@@ -12,4 +12,8 @@
     <PackageReference Include="Markdig" Version="0.31.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Kysect.Configuin.Common\Kysect.Configuin.Common.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/Sources/Kysect.Configuin.Core/MsLearnDocumentation/MsLearnDocumentationParser.cs
+++ b/Sources/Kysect.Configuin.Core/MsLearnDocumentation/MsLearnDocumentationParser.cs
@@ -64,7 +64,7 @@ public class MsLearnDocumentationParser : IMsLearnDocumentationParser
         IReadOnlyCollection<RoslynStyleRuleOption> roslynStyleRuleOptions = ParseOptions(markdownHeadedBlocks);
 
         return new RoslynStyleRule(
-            ruleId.Value,
+            RoslynRuleId.Parse(ruleId.Value),
             title.Value,
             category.Value,
             overviewText,
@@ -99,7 +99,7 @@ public class MsLearnDocumentationParser : IMsLearnDocumentationParser
         MsLearnPropertyValueDescriptionTableRow isDefault = table.GetSingleValue("Enabled by default in .NET 7");
 
         return new RoslynQualityRule(
-            ruleId.Value,
+            RoslynRuleId.Parse(ruleId.Value),
             // TODO: parse rule name
             ruleName: string.Empty,
             category.Value,

--- a/Sources/Kysect.Configuin.Core/RoslynRuleModels/RoslynQualityRule.cs
+++ b/Sources/Kysect.Configuin.Core/RoslynRuleModels/RoslynQualityRule.cs
@@ -2,12 +2,12 @@
 
 public class RoslynQualityRule
 {
-    public string RuleId { get; }
+    public RoslynRuleId RuleId { get; }
     public string RuleName { get; }
     public string Category { get; }
     public string Description { get; }
 
-    public RoslynQualityRule(string ruleId, string ruleName, string category, string description)
+    public RoslynQualityRule(RoslynRuleId ruleId, string ruleName, string category, string description)
     {
         RuleId = ruleId;
         RuleName = ruleName;

--- a/Sources/Kysect.Configuin.Core/RoslynRuleModels/RoslynRuleId.cs
+++ b/Sources/Kysect.Configuin.Core/RoslynRuleModels/RoslynRuleId.cs
@@ -13,7 +13,7 @@ public readonly struct RoslynRuleId
         string qualityRulePrefix = "CA";
         if (value.StartsWith(qualityRulePrefix, StringComparison.InvariantCultureIgnoreCase))
         {
-            string id = value.RemovePrefix(qualityRulePrefix);
+            string id = value.WithoutPrefix(qualityRulePrefix);
             return new RoslynRuleId(RoslynRuleType.QualityRule, int.Parse(id));
         }
 
@@ -21,8 +21,8 @@ public readonly struct RoslynRuleId
         string styleRulePrefix = "IDE";
         if (value.StartsWith(styleRulePrefix, StringComparison.InvariantCultureIgnoreCase))
         {
-            string id = value.RemovePrefix(styleRulePrefix);
-            return new RoslynRuleId(RoslynRuleType.QualityRule, int.Parse(id));
+            string id = value.WithoutPrefix(styleRulePrefix);
+            return new RoslynRuleId(RoslynRuleType.StyleRule, int.Parse(id));
         }
 
         throw new ArgumentException($"String {value} is not valid Roslyn rule id");

--- a/Sources/Kysect.Configuin.Core/RoslynRuleModels/RoslynRuleId.cs
+++ b/Sources/Kysect.Configuin.Core/RoslynRuleModels/RoslynRuleId.cs
@@ -1,0 +1,36 @@
+﻿using Kysect.Configuin.Common;
+
+namespace Kysect.Configuin.Core.RoslynRuleModels;
+
+public struct RoslynRuleId
+{
+    public RoslynRuleType Type { get; }
+    public int Id { get; }
+
+    public static RoslynRuleId Parse(string value)
+    {
+        // CA1234
+        string qualityRulePrefix = "CA";
+        if (value.StartWithIgnoreCase(qualityRulePrefix))
+        {
+            string id = value.RemovePrefix(qualityRulePrefix);
+            return new RoslynRuleId(RoslynRuleType.QualityRule, int.Parse(id));
+        }
+
+        // IDE1234
+        string styleRulePrefix = "IDE";
+        if (value.StartWithIgnoreCase(styleRulePrefix))
+        {
+            string id = value.RemovePrefix(styleRulePrefix);
+            return new RoslynRuleId(RoslynRuleType.QualityRule, int.Parse(id));
+        }
+
+        throw new ArgumentException($"String {value} is not valid Roslyn rule id");
+    }
+
+    public RoslynRuleId(RoslynRuleType type, int id)
+    {
+        Type = type;
+        Id = id;
+    }
+}

--- a/Sources/Kysect.Configuin.Core/RoslynRuleModels/RoslynRuleId.cs
+++ b/Sources/Kysect.Configuin.Core/RoslynRuleModels/RoslynRuleId.cs
@@ -11,7 +11,7 @@ public readonly struct RoslynRuleId
     {
         // CA1234
         string qualityRulePrefix = "CA";
-        if (value.StartWithIgnoreCase(qualityRulePrefix))
+        if (value.StartsWith(qualityRulePrefix, StringComparison.InvariantCultureIgnoreCase))
         {
             string id = value.RemovePrefix(qualityRulePrefix);
             return new RoslynRuleId(RoslynRuleType.QualityRule, int.Parse(id));
@@ -19,7 +19,7 @@ public readonly struct RoslynRuleId
 
         // IDE1234
         string styleRulePrefix = "IDE";
-        if (value.StartWithIgnoreCase(styleRulePrefix))
+        if (value.StartsWith(styleRulePrefix, StringComparison.InvariantCultureIgnoreCase))
         {
             string id = value.RemovePrefix(styleRulePrefix);
             return new RoslynRuleId(RoslynRuleType.QualityRule, int.Parse(id));

--- a/Sources/Kysect.Configuin.Core/RoslynRuleModels/RoslynRuleId.cs
+++ b/Sources/Kysect.Configuin.Core/RoslynRuleModels/RoslynRuleId.cs
@@ -2,7 +2,7 @@
 
 namespace Kysect.Configuin.Core.RoslynRuleModels;
 
-public struct RoslynRuleId
+public readonly struct RoslynRuleId
 {
     public RoslynRuleType Type { get; }
     public int Id { get; }
@@ -32,5 +32,23 @@ public struct RoslynRuleId
     {
         Type = type;
         Id = id;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is RoslynRuleId o)
+            return Equals(o);
+
+        return false;
+    }
+
+    public bool Equals(RoslynRuleId other)
+    {
+        return Type == other.Type && Id == other.Id;
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine((int)Type, Id);
     }
 }

--- a/Sources/Kysect.Configuin.Core/RoslynRuleModels/RoslynRuleType.cs
+++ b/Sources/Kysect.Configuin.Core/RoslynRuleModels/RoslynRuleType.cs
@@ -1,0 +1,7 @@
+﻿namespace Kysect.Configuin.Core.RoslynRuleModels;
+
+public enum RoslynRuleType
+{
+    StyleRule,
+    QualityRule
+}

--- a/Sources/Kysect.Configuin.Core/RoslynRuleModels/RoslynStyleRule.cs
+++ b/Sources/Kysect.Configuin.Core/RoslynRuleModels/RoslynStyleRule.cs
@@ -2,14 +2,14 @@
 
 public class RoslynStyleRule
 {
-    public string RuleId { get; }
+    public RoslynRuleId RuleId { get; }
     public string Title { get; }
     public string Category { get; }
     public string Overview { get; }
     public string Example { get; }
     public IReadOnlyCollection<RoslynStyleRuleOption> Options { get; }
 
-    public RoslynStyleRule(string ruleId, string title, string category, string overview, string example, IReadOnlyCollection<RoslynStyleRuleOption> options)
+    public RoslynStyleRule(RoslynRuleId ruleId, string title, string category, string overview, string example, IReadOnlyCollection<RoslynStyleRuleOption> options)
     {
         RuleId = ruleId;
         Title = title;

--- a/Sources/Kysect.Configuin.Tests/EditorConfigFileParsing/EditorConfigRuleParserTests.cs
+++ b/Sources/Kysect.Configuin.Tests/EditorConfigFileParsing/EditorConfigRuleParserTests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using Kysect.Configuin.Core.EditorConfigParsing;
 using Kysect.Configuin.Core.EditorConfigParsing.Rules;
+using Kysect.Configuin.Core.RoslynRuleModels;
 using NUnit.Framework;
 
 namespace Kysect.Configuin.Tests.EditorConfigFileParsing;
@@ -26,7 +27,8 @@ public class EditorConfigRuleParserTests
     public void Parse_DotnetDiagnosticSeverity_ReturnRoslyntSeverityRule()
     {
         string content = "dotnet_diagnostic.IDE0001.severity = warning";
-        var expected = new RoslynSeverityEditorConfigRule("IDE0001", RoslynRuleSeverity.Warning);
+        var roslynRuleId = RoslynRuleId.Parse("IDE0001");
+        var expected = new RoslynSeverityEditorConfigRule(roslynRuleId, RoslynRuleSeverity.Warning);
 
         EditorConfigRuleSet editorConfigRuleSet = _parser.Parse(content);
 

--- a/Sources/Kysect.Configuin.Tests/MsLearnDocumentation/MsLearnDocumentationParserTests.cs
+++ b/Sources/Kysect.Configuin.Tests/MsLearnDocumentation/MsLearnDocumentationParserTests.cs
@@ -21,11 +21,12 @@ public class MsLearnDocumentationParserTests
     public void ParseStyleRule_IDE0040_ReturnExpectedResult()
     {
         string fileText = File.ReadAllText(Path.Combine("MsLearnDocumentation", "Resources", "Ide0040.md"));
+        RoslynRuleId expected = RoslynRuleId.Parse("IDE0040");
 
         RoslynStyleRule roslynStyleRule = _parser.ParseStyleRule(fileText);
 
         roslynStyleRule.RuleId
-            .Should().Be("IDE0040");
+            .Should().Be(expected);
 
         roslynStyleRule.Title
             .Should().Be("Add accessibility modifiers");
@@ -57,12 +58,13 @@ public class MsLearnDocumentationParserTests
     public void ParseQualityRule_CS1064_ReturnExpectedResult()
     {
         string fileText = File.ReadAllText(Path.Combine("MsLearnDocumentation", "Resources", "Ca1064.md"));
+        RoslynRuleId expected = RoslynRuleId.Parse("CA1064");
 
         RoslynQualityRule qualityRule = _parser.ParseQualityRule(fileText);
 
         qualityRule.RuleId
-            .Should().Be("CA1064");
-        
+            .Should().Be(expected);
+
         qualityRule.Category
             .Should().Be("Design");
 

--- a/Sources/Kysect.Configuin.Tests/MsLearnDocumentation/RoslynRuleIdTests.cs
+++ b/Sources/Kysect.Configuin.Tests/MsLearnDocumentation/RoslynRuleIdTests.cs
@@ -1,0 +1,30 @@
+﻿using FluentAssertions;
+using Kysect.Configuin.Core.RoslynRuleModels;
+using NUnit.Framework;
+
+namespace Kysect.Configuin.Tests.MsLearnDocumentation;
+
+public class RoslynRuleIdTests
+{
+    [Test]
+    [TestCase("CA1000", RoslynRuleType.QualityRule, 1000)]
+    [TestCase("ca1001", RoslynRuleType.QualityRule, 1001)]
+    [TestCase("IDE1002", RoslynRuleType.StyleRule, 1002)]
+    public void Parse(string input, RoslynRuleType type, int id)
+    {
+        var expected = new RoslynRuleId(type, id);
+
+        var roslynRuleId = RoslynRuleId.Parse(input);
+
+        roslynRuleId.Should().Be(expected);
+    }
+
+    [Test]
+    public void Parse_WithIncorrectPrefix_ThrowException()
+    {
+        Assert.Throws<ArgumentException>(() =>
+        {
+            var roslynRuleId = RoslynRuleId.Parse("QWE1234");
+        });
+    }
+}


### PR DESCRIPTION
Related to #6 

Решил выделить в отдельный PR это. Добавил тип-обёртку над строкой для rule id.