### PR TITLE
Implement CA* rule title parsing

### DIFF
--- a/Sources/Kysect.Configuin.Common/Kysect.Configuin.Common.csproj
+++ b/Sources/Kysect.Configuin.Common/Kysect.Configuin.Common.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Kysect.Editorconfig" Version="1.0.4" />
+    <PackageReference Include="Kysect.Editorconfig" Version="1.0.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />

--- a/Sources/Kysect.Configuin.Console/Kysect.Configuin.Console.csproj
+++ b/Sources/Kysect.Configuin.Console/Kysect.Configuin.Console.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Kysect.Editorconfig" Version="1.0.4" />
+    <PackageReference Include="Kysect.Editorconfig" Version="1.0.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />

--- a/Sources/Kysect.Configuin.Core/CodeStyleGeneration/Markdown/MarkdownCodeStyleFormatter.cs
+++ b/Sources/Kysect.Configuin.Core/CodeStyleGeneration/Markdown/MarkdownCodeStyleFormatter.cs
@@ -50,7 +50,7 @@ public class MarkdownCodeStyleFormatter : ICodeStyleFormatter
     {
         var builder = new MarkdownStringBuilder();
 
-        builder.AddH2(rule.Rule.RuleId.ToString());
+        builder.AddH2($"{rule.Rule.Title} ({rule.Rule.RuleId})");
         builder.AddEmptyLine();
         builder.AddText($"Severity: {rule.Severity}");
 

--- a/Sources/Kysect.Configuin.Core/Kysect.Configuin.Core.csproj
+++ b/Sources/Kysect.Configuin.Core/Kysect.Configuin.Core.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Kysect.CommonLib" Version="0.1.6" />
-    <PackageReference Include="Kysect.Editorconfig" Version="1.0.4" />
+    <PackageReference Include="Kysect.Editorconfig" Version="1.0.5" />
     <PackageReference Include="Markdig" Version="0.33.0" />
   </ItemGroup>
 

--- a/Sources/Kysect.Configuin.Core/MsLearnDocumentation/MsLearnDocumentationParser.cs
+++ b/Sources/Kysect.Configuin.Core/MsLearnDocumentation/MsLearnDocumentationParser.cs
@@ -124,6 +124,7 @@ public class MsLearnDocumentationParser : IMsLearnDocumentationParser
         MsLearnPropertyValueDescriptionTable table = _msLearnTableParser.Parse(markdownTableContent);
 
         MsLearnPropertyValueDescriptionTableRow ruleId = table.GetSingleValue("Rule ID");
+        MsLearnPropertyValueDescriptionTableRow title = table.GetSingleValue("Title");
         MsLearnPropertyValueDescriptionTableRow category = table.GetSingleValue("Category");
         // TODO: add this fields to model
         MsLearnPropertyValueDescriptionTableRow breakingChanges = table.GetSingleValue("Fix is breaking or non-breaking");
@@ -136,8 +137,7 @@ public class MsLearnDocumentationParser : IMsLearnDocumentationParser
         return ruleIds
             .Select(id => new RoslynQualityRule(
                 id,
-                // TODO: #40 parse rule name
-                ruleName: string.Empty,
+                title.Value,
                 category.Value,
                 // TODO: #41 parse description
                 description: string.Empty))

--- a/Sources/Kysect.Configuin.Core/MsLearnDocumentation/Tables/MsLearnTableParser.cs
+++ b/Sources/Kysect.Configuin.Core/MsLearnDocumentation/Tables/MsLearnTableParser.cs
@@ -57,13 +57,11 @@ public class MsLearnTableParser
         if (simpleTable.Headers.Count != 2 && simpleTable.Headers.Count != 3)
             throw new ArgumentException($"Unexpected column count in property-value table. Expected 2 or 3, but was {simpleTable.Headers.Count}");
 
-        // TODO: This validation sometimes throw error. In some cases table has "Item" column instead of "Property".
-        // Maybe we need to drop it.
-        //string[] expectedHeaders = { "Property", "Value", "Description" };
-        //for (int i = 0; i < simpleTable.Headers.Count; i++)
-        //{
-        //    if (!string.IsNullOrEmpty(simpleTable.Headers[i]) && simpleTable.Headers[i] != expectedHeaders[i])
-        //        throw new ArgumentException($"Table header on index {i} must be equal to {expectedHeaders[i]} but was {simpleTable.Headers[i]}");
-        //}
+        string[] expectedHeaders = { "Property", "Value", "Description" };
+        for (int i = 0; i < simpleTable.Headers.Count; i++)
+        {
+            if (simpleTable.Headers[i] != expectedHeaders[i])
+                throw new ArgumentException($"Table header on index {i} must be equal to {expectedHeaders[i]} but was {simpleTable.Headers[i]}");
+        }
     }
 }

--- a/Sources/Kysect.Configuin.Core/RoslynRuleModels/RoslynQualityRule.cs
+++ b/Sources/Kysect.Configuin.Core/RoslynRuleModels/RoslynQualityRule.cs
@@ -3,14 +3,14 @@
 public class RoslynQualityRule
 {
     public RoslynRuleId RuleId { get; }
-    public string RuleName { get; }
+    public string Title { get; }
     public string Category { get; }
     public string Description { get; }
 
-    public RoslynQualityRule(RoslynRuleId ruleId, string ruleName, string category, string description)
+    public RoslynQualityRule(RoslynRuleId ruleId, string title, string category, string description)
     {
         RuleId = ruleId;
-        RuleName = ruleName;
+        Title = title;
         Category = category;
         Description = description;
     }

--- a/Sources/Kysect.Configuin.Tests/CodeStyleGeneration/MarkdownCodeStyleFormatterTests.cs
+++ b/Sources/Kysect.Configuin.Tests/CodeStyleGeneration/MarkdownCodeStyleFormatterTests.cs
@@ -56,10 +56,9 @@ public class MarkdownCodeStyleFormatterTests
     [Test]
     public void FormatQualityRule_ForCA1064_ReturnExpected()
     {
-        // TODO: change CA1064 -> Exceptions should be public (CA1064)
         // TODO: add description
         const string expected = """
-                                ## CA1064
+                                ## Exceptions should be public (CA1064)
 
                                 Severity: Warning
 

--- a/Sources/Kysect.Configuin.Tests/MsLearnDocumentation/MsLearnDocumentationParserTests.cs
+++ b/Sources/Kysect.Configuin.Tests/MsLearnDocumentation/MsLearnDocumentationParserTests.cs
@@ -149,8 +149,7 @@ public class MsLearnDocumentationParserTests
         // TODO: parse description
         var expected = new RoslynQualityRule(
             RoslynRuleId.Parse("CA1865"),
-            // TODO: parse name?
-            ruleName: string.Empty,
+            "Use 'string.Method(char)' instead of 'string.Method(string)' for string with single char",
             category: "Performance",
             // TODO: parse description?
             description: string.Empty);

--- a/Sources/Kysect.Configuin.Tests/MsLearnDocumentation/MsLearnTableParserTests.cs
+++ b/Sources/Kysect.Configuin.Tests/MsLearnDocumentation/MsLearnTableParserTests.cs
@@ -21,7 +21,7 @@ public class MsLearnTableParserTests
     public void Parse_KeyValueTable_ReturnExpectedResult()
     {
         string input = """
-                    |                                     | Value                        |
+                    | Property                            | Value                        |
                     |-------------------------------------|------------------------------|
                     | **Rule ID**                         | CA1000                       |
                     | **Category**                        | [Design](design-warnings.md) |

--- a/Sources/Kysect.Configuin.Tests/Resources/WellKnownRoslynRuleDefinitions.cs
+++ b/Sources/Kysect.Configuin.Tests/Resources/WellKnownRoslynRuleDefinitions.cs
@@ -46,11 +46,11 @@ public static class WellKnownRoslynRuleDefinitions
 
     public static RoslynQualityRule CA1064()
     {
-        // TODO: parse description
         return new RoslynQualityRule(
             RoslynRuleId.Parse("CA1064"),
-            string.Empty,
+            "Exceptions should be public",
             "Design",
+            // TODO: parse description
             string.Empty);
     }
 }


### PR DESCRIPTION
Close #40 

В репозиторий с доками добавил все заголовки, теперь их можно парсить! Заодно вернул валидацию заголовок таблиц, которая падала из-за того, что местами не корректные header'ы были.