### PR TITLE
Implement temporary file moving with undo

### DIFF
--- a/Sources/Kysect.Configuin.Core/FileSystem/DeleteFileOperation.cs
+++ b/Sources/Kysect.Configuin.Core/FileSystem/DeleteFileOperation.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace Kysect.Configuin.Core.FileSystem;
+
+public class DeleteFileOperation : IFileMoveUndoOperation
+{
+    private readonly string _path;
+    private readonly ILogger _logger;
+
+    public DeleteFileOperation(string path, ILogger logger)
+    {
+        _path = path;
+        _logger = logger;
+    }
+
+    public void Execute()
+    {
+        _logger.LogInformation("Undo file move. Delete {path}", _path);
+        File.Delete(_path);
+    }
+}

--- a/Sources/Kysect.Configuin.Core/FileSystem/IFileMoveUndoOperation.cs
+++ b/Sources/Kysect.Configuin.Core/FileSystem/IFileMoveUndoOperation.cs
@@ -1,0 +1,6 @@
+﻿namespace Kysect.Configuin.Core.FileSystem;
+
+public interface IFileMoveUndoOperation
+{
+    void Execute();
+}

--- a/Sources/Kysect.Configuin.Core/FileSystem/MoveBackFileOperation.cs
+++ b/Sources/Kysect.Configuin.Core/FileSystem/MoveBackFileOperation.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace Kysect.Configuin.Core.FileSystem;
+
+public class MoveBackFileOperation : IFileMoveUndoOperation
+{
+    private readonly string _source;
+    private readonly string _target;
+    private readonly ILogger _logger;
+
+    public MoveBackFileOperation(string source, string target, ILogger logger)
+    {
+        _source = source;
+        _target = target;
+        _logger = logger;
+    }
+
+    public void Execute()
+    {
+        _logger.LogInformation("Undo file move. Move backup file from {source} to {target}", _source, _target);
+        File.Move(_source, _target, overwrite: true);
+    }
+}

--- a/Sources/Kysect.Configuin.Core/FileSystem/TemporaryFileReplacer.cs
+++ b/Sources/Kysect.Configuin.Core/FileSystem/TemporaryFileReplacer.cs
@@ -1,0 +1,41 @@
+﻿using Kysect.CommonLib.FileSystem.Extensions;
+using Microsoft.Extensions.Logging;
+
+namespace Kysect.Configuin.Core.FileSystem;
+
+public class TemporaryFileMover
+{
+    private readonly string _tempDirectory;
+    private readonly ILogger _logger;
+
+    public TemporaryFileMover(string tempDirectory, ILogger logger)
+    {
+        _tempDirectory = tempDirectory;
+        _logger = logger;
+    }
+
+    public IFileMoveUndoOperation MoveFile(string sourcePath, string targetPath)
+    {
+        _logger.LogInformation("Move {sourcePath} to {targetPath}", sourcePath, targetPath);
+        DirectoryExtensions.EnsureFileExists(_tempDirectory);
+
+        if (!File.Exists(sourcePath))
+            throw new FileNotFoundException(sourcePath);
+
+        if (File.Exists(targetPath))
+        {
+            var targetFileInfo = new FileInfo(targetPath);
+            string tempFilePath = Path.Combine(_tempDirectory, targetFileInfo.Name);
+            _logger.LogInformation("Target path already exists. Save target file to temp path {tempPath}", tempFilePath);
+            _logger.LogInformation("Move {targetPath} to {tempFilePath}", targetPath, tempFilePath);
+            File.Move(targetPath, tempFilePath);
+            _logger.LogInformation("Copy {sourcePath} to {targetPath}", sourcePath, targetPath);
+            File.Copy(sourcePath, targetPath, overwrite: true);
+            return new MoveBackFileOperation(tempFilePath, targetPath, _logger);
+        }
+
+        _logger.LogInformation("Target path is not exists. Copy {source} to {target}", sourcePath, targetPath);
+        File.Copy(sourcePath, targetPath);
+        return new DeleteFileOperation(targetPath, _logger);
+    }
+}

--- a/Sources/Kysect.Configuin.Tests/TemporaryFileMoverTests.cs
+++ b/Sources/Kysect.Configuin.Tests/TemporaryFileMoverTests.cs
@@ -1,0 +1,78 @@
+﻿using FluentAssertions;
+using Kysect.CommonLib.FileSystem.Extensions;
+using Kysect.Configuin.Core.FileSystem;
+using Kysect.Configuin.Tests.Tools;
+using NUnit.Framework;
+
+namespace Kysect.Configuin.Tests;
+
+public class TemporaryFileMoverTests
+{
+    private const string TestGenerated = "TemporaryFileMoverTests";
+
+    private readonly TemporaryFileMover _sut;
+
+    public TemporaryFileMoverTests()
+    {
+        _sut = new TemporaryFileMover(Path.Combine(TestGenerated, "TempDir"), TestLogger.ProviderForTests());
+    }
+
+    [SetUp]
+    public void Setup()
+    {
+        DirectoryExtensions.EnsureFileExists(TestGenerated);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Directory.Delete(TestGenerated, recursive: true);
+    }
+
+    [Test]
+    public void MoveFile_WhenTargetNotExists_UndoDeleteFile()
+    {
+        string fileForMove = CreateFile("file_for_move");
+        string targetPath = GeneratePath("target");
+
+        IFileMoveUndoOperation undoAction = _sut.MoveFile(fileForMove, targetPath);
+        File.Exists(targetPath).Should().BeTrue();
+
+        undoAction.Execute();
+        File.Exists(targetPath).Should().BeFalse();
+    }
+
+    [Test]
+    public void MoveFile_WhenTargetExists_UndoReturnOriginalFile()
+    {
+        string fileForMove = CreateFile("file_for_move");
+        string targetFile = CreateFile("target");
+
+        File.Exists(targetFile).Should().BeTrue();
+        File.ReadAllText(targetFile).Should().Be(targetFile);
+
+        IFileMoveUndoOperation undoAction = _sut.MoveFile(fileForMove, targetFile);
+
+        File.Exists(targetFile).Should().BeTrue();
+        File.ReadAllText(targetFile).Should().Be(fileForMove);
+
+        undoAction.Execute();
+
+        File.Exists(targetFile).Should().BeTrue();
+        File.ReadAllText(targetFile).Should().Be(targetFile);
+    }
+
+    private static string CreateFile(string prefix)
+    {
+        string path = GeneratePath(prefix);
+
+        File.WriteAllText(path: path, contents: path);
+
+        return path;
+    }
+
+    private static string GeneratePath(string prefix)
+    {
+        return Path.Combine(TestGenerated, $"{prefix}_{Guid.NewGuid().ToString()}");
+    }
+}


### PR DESCRIPTION
Related to #51 

Реализовал логику для временного копирования файла с возможностью сделать undo. Будет использоваться для подменты .editorconfig'а.

Два основных режима:

- Когда файла по таргетному пути нет. Копируется, на анду - удаляется
- Когда файл по таргетному пути есть. Он копируется во временную директорию, заменяется. На анду обратно пишутся из темпового файла содержимое.