### PR TITLE
Implement missed .editorconfig values analyzer

### DIFF
--- a/Sources/Directory.Build.props
+++ b/Sources/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
         <LangVersion>latest</LangVersion>
-        <NoWarn>$(NoWarn);CS1591;CA1707</NoWarn>
+        <NoWarn>$(NoWarn);CS1591;CA1707;IDE0055</NoWarn>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/Sources/Kysect.Configuin.Console/Program.cs
+++ b/Sources/Kysect.Configuin.Console/Program.cs
@@ -4,4 +4,5 @@ IServiceProvider s = DependencyBuilder.InitializeServiceProvider();
 var configuinCommands = new ConfiguinCommands(s);
 
 //configuinCommands.GenerateCodeStyle();
-configuinCommands.GetEditorConfigWarningUpdates();
+//configuinCommands.GetEditorConfigWarningUpdates();
+configuinCommands.GetMissedConfiguration();

--- a/Sources/Kysect.Configuin.EditorConfig/EditorConfigAnalyzer.cs
+++ b/Sources/Kysect.Configuin.EditorConfig/EditorConfigAnalyzer.cs
@@ -1,0 +1,44 @@
+﻿using Kysect.Configuin.EditorConfig.Settings;
+using Kysect.Configuin.RoslynModels;
+
+namespace Kysect.Configuin.EditorConfig;
+
+public class EditorConfigAnalyzer
+{
+    public EditorConfigMissedConfiguration GetMissedConfigurations(EditorConfigSettings editorConfigSettings, RoslynRules roslynRules)
+    {
+        var selectedSeverity = editorConfigSettings
+            .Settings
+            .OfType<RoslynSeverityEditorConfigSetting>()
+            .Select(c => c.RuleId)
+            .ToHashSet();
+
+        var selectedOptions = editorConfigSettings
+            .Settings
+            .OfType<RoslynOptionEditorConfigSetting>()
+            .Select(c => c.Key)
+            .ToHashSet();
+
+        var missedStyleRules = roslynRules
+            .StyleRules
+            .Where(rule => !selectedSeverity.Contains(rule.RuleId))
+            .Select(r => r.RuleId)
+            .Order()
+            .ToList();
+
+        var missedQualityRules = roslynRules
+            .QualityRules
+            .Where(rule => !selectedSeverity.Contains(rule.RuleId))
+            .Select(r => r.RuleId)
+            .Order()
+            .ToList();
+
+        var missedOptions = roslynRules
+            .GetOptions()
+            .Where(option => !selectedOptions.Contains(option.Name))
+            .Select(o => o.Name)
+            .ToList();
+
+        return new EditorConfigMissedConfiguration(missedStyleRules, missedQualityRules, missedOptions);
+    }
+}

--- a/Sources/Kysect.Configuin.EditorConfig/EditorConfigMissedConfiguration.cs
+++ b/Sources/Kysect.Configuin.EditorConfig/EditorConfigMissedConfiguration.cs
@@ -1,0 +1,8 @@
+﻿using Kysect.Configuin.RoslynModels;
+
+namespace Kysect.Configuin.EditorConfig;
+
+public record EditorConfigMissedConfiguration(
+    IReadOnlyCollection<RoslynRuleId> StyleRuleSeverity,
+    IReadOnlyCollection<RoslynRuleId> QualityRuleSeverity,
+    IReadOnlyCollection<string> StyleRuleOptions);

--- a/Sources/Kysect.Configuin.RoslynModels/RoslynRuleId.cs
+++ b/Sources/Kysect.Configuin.RoslynModels/RoslynRuleId.cs
@@ -2,7 +2,7 @@
 
 namespace Kysect.Configuin.RoslynModels;
 
-public readonly struct RoslynRuleId
+public readonly struct RoslynRuleId : IComparable<RoslynRuleId>
 {
     public RoslynRuleType Type { get; }
     public int Id { get; }
@@ -63,5 +63,13 @@ public readonly struct RoslynRuleId
     public override string ToString()
     {
         return $"{Type.ToAlias()}{Id:D4}";
+    }
+
+    public int CompareTo(RoslynRuleId other)
+    {
+        int typeComparison = Type.CompareTo(other.Type);
+        if (typeComparison != 0)
+            return typeComparison;
+        return Id.CompareTo(other.Id);
     }
 }

--- a/Sources/Kysect.Configuin.Tests/EditorConfig/EditorConfigAnalyzerTests.cs
+++ b/Sources/Kysect.Configuin.Tests/EditorConfig/EditorConfigAnalyzerTests.cs
@@ -1,0 +1,55 @@
+﻿using FluentAssertions;
+using Kysect.Configuin.EditorConfig;
+using Kysect.Configuin.EditorConfig.Settings;
+using Kysect.Configuin.RoslynModels;
+using Kysect.Configuin.Tests.Resources;
+using NUnit.Framework;
+
+namespace Kysect.Configuin.Tests.EditorConfig;
+
+public class EditorConfigAnalyzerTests
+{
+    [Test]
+    public void GetMissedConfigurations_AllOptionAreMissed_ReturnAllOptions()
+    {
+        var editorConfigAnalyzer = new EditorConfigAnalyzer();
+
+        var editorConfigSettings = new EditorConfigSettings(Array.Empty<IEditorConfigSetting>());
+        var roslynRules = new RoslynRules(new[] { WellKnownRoslynRuleDefinitions.CA1064() }, new[] { WellKnownRoslynRuleDefinitions.IDE0040() });
+
+        EditorConfigMissedConfiguration editorConfigMissedConfiguration = editorConfigAnalyzer.GetMissedConfigurations(editorConfigSettings, roslynRules);
+
+        editorConfigMissedConfiguration.QualityRuleSeverity
+            .Should().HaveCount(1)
+            .And.Contain(WellKnownRoslynRuleDefinitions.CA1064().RuleId);
+
+        editorConfigMissedConfiguration.StyleRuleSeverity
+            .Should().HaveCount(1)
+            .And.Contain(WellKnownRoslynRuleDefinitions.IDE0040().RuleId);
+
+        editorConfigMissedConfiguration.StyleRuleOptions
+            .Should().HaveCount(1)
+            .And.Contain(WellKnownRoslynRuleDefinitions.IDE0040().Options.Single().Name);
+    }
+
+    [Test]
+    public void GetMissedConfigurations_AllOptionExists_ReturnAllOptions()
+    {
+        var editorConfigAnalyzer = new EditorConfigAnalyzer();
+
+        var editorConfigSettings = new EditorConfigSettings(new IEditorConfigSetting[]
+        {
+            new RoslynSeverityEditorConfigSetting(WellKnownRoslynRuleDefinitions.IDE0040().RuleId, RoslynRuleSeverity.Warning),
+            new RoslynSeverityEditorConfigSetting(WellKnownRoslynRuleDefinitions.CA1064().RuleId, RoslynRuleSeverity.Warning),
+            new RoslynOptionEditorConfigSetting(WellKnownRoslynRuleDefinitions.IDE0040().Options.Single().Name, "always")
+        });
+
+        var roslynRules = new RoslynRules(new[] { WellKnownRoslynRuleDefinitions.CA1064() }, new[] { WellKnownRoslynRuleDefinitions.IDE0040() });
+
+        EditorConfigMissedConfiguration editorConfigMissedConfiguration = editorConfigAnalyzer.GetMissedConfigurations(editorConfigSettings, roslynRules);
+
+        editorConfigMissedConfiguration.QualityRuleSeverity.Should().BeEmpty();
+        editorConfigMissedConfiguration.StyleRuleSeverity.Should().BeEmpty();
+        editorConfigMissedConfiguration.StyleRuleOptions.Should().BeEmpty();
+    }
+}

--- a/Sources/Kysect.Configuin.Tests/EditorConfig/EditorConfigSettingsParserTests.cs
+++ b/Sources/Kysect.Configuin.Tests/EditorConfig/EditorConfigSettingsParserTests.cs
@@ -5,7 +5,7 @@ using Kysect.Configuin.RoslynModels;
 using Kysect.Configuin.Tests.Tools;
 using NUnit.Framework;
 
-namespace Kysect.Configuin.Tests.EditorConfigSettingsParsing;
+namespace Kysect.Configuin.Tests.EditorConfig;
 
 public class EditorConfigSettingsParserTests
 {

--- a/Sources/Kysect.Configuin.Tests/EditorConfig/IniParserTests.cs
+++ b/Sources/Kysect.Configuin.Tests/EditorConfig/IniParserTests.cs
@@ -2,7 +2,7 @@
 using Kysect.Configuin.EditorConfig.IniParsing;
 using NUnit.Framework;
 
-namespace Kysect.Configuin.Tests.EditorConfigSettingsParsing;
+namespace Kysect.Configuin.Tests.EditorConfig;
 
 public class IniParserTests
 {


### PR DESCRIPTION
Close #65 

Реализовал поиск не добавленных значений в .editorconfig.