### PR TITLE
Add code samples for IDE* rules in .editorconfig template generating

### DIFF
--- a/Sources/Kysect.Configuin.EditorConfig/Template/EditorConfigTemplateGenerator.cs
+++ b/Sources/Kysect.Configuin.EditorConfig/Template/EditorConfigTemplateGenerator.cs
@@ -24,6 +24,8 @@ public class EditorConfigTemplateGenerator
             {
                 builder.AddDoubleCommentString($"{roslynStyleRule.Title} ({roslynStyleRule.RuleId})");
                 builder.AddDoubleCommentString(roslynStyleRule.Overview);
+                if (roslynStyleRule.Example is not null)
+                    builder.AddDoubleCommentString(roslynStyleRule.Example);
                 builder.AddCommentString($"dotnet_diagnostic.{roslynStyleRule.RuleId}.severity = ");
                 builder.AddEmptyLine();
             }

--- a/Sources/Kysect.Configuin.Tests/EditorConfig/EditorConfigTemplateGeneratorTests.cs
+++ b/Sources/Kysect.Configuin.Tests/EditorConfig/EditorConfigTemplateGeneratorTests.cs
@@ -17,6 +17,35 @@ public class EditorConfigTemplateGeneratorTests
     }
 
     [Test]
+    public void GenerateTemplate_ForIDE0001_ReturnExpectedString()
+    {   
+        RoslynRules roslynRules = RoslynRulesBuilder.New()
+            .AddStyle(WellKnownRoslynRuleDefinitions.IDE0001())
+            .Build();
+
+        string expected = """
+                          ## Simplify name (IDE0001)
+                          ## This rule concerns the use of simplified type names in declarations and executable code, when possible. You can remove unnecessary name qualification to simplify code and improve readability.
+                          ## using System.IO;
+                          ## class C
+                          ## {
+                          ##     // IDE0001: 'System.IO.FileInfo' can be simplified to 'FileInfo'
+                          ##     System.IO.FileInfo file;
+                          ## 
+                          ##     // Fixed code
+                          ##     FileInfo file;
+                          ## }
+                          # dotnet_diagnostic.IDE0001.severity = 
+
+
+                          """;
+
+        string generateTemplate = _editorConfigTemplateGenerator.GenerateTemplate(roslynRules);
+
+        generateTemplate.Should().Be(expected);
+    }
+
+    [Test]
     public void GenerateTemplate_ForIDE0040_ReturnExpectedString()
     {
         RoslynRules roslynRules = RoslynRulesBuilder.New()

--- a/Sources/Kysect.Configuin.Tests/EditorConfig/EditorConfigTemplateGeneratorTests.cs
+++ b/Sources/Kysect.Configuin.Tests/EditorConfig/EditorConfigTemplateGeneratorTests.cs
@@ -18,7 +18,7 @@ public class EditorConfigTemplateGeneratorTests
 
     [Test]
     public void GenerateTemplate_ForIDE0001_ReturnExpectedString()
-    {   
+    {
         RoslynRules roslynRules = RoslynRulesBuilder.New()
             .AddStyle(WellKnownRoslynRuleDefinitions.IDE0001())
             .Build();


### PR DESCRIPTION
Обнаружил, что code sample не используется, только примеры от опций.